### PR TITLE
lib/LXRng/Index/PgBatch.pm: use a defined value with pg_putline

### DIFF
--- a/lib/LXRng/Index/PgBatch.pm
+++ b/lib/LXRng/Index/PgBatch.pm
@@ -104,8 +104,9 @@ sub flush {
 	    $self->dbh->do(qq{copy $pre$table from stdin});
 	    while ($len > 0) {
 		$i++;
-		$self->dbh->pg_putline(substr($$cache{$table}, $idx,
-						  $len > 4096 ? 4096 : $len));
+		my $line = substr($$cache{$table}, $idx,
+				  $len > 4096 ? 4096 : $len);
+		$self->dbh->pg_putline($line);
 		$idx += 4096;
 		$len -= 4096;
 	    }


### PR DESCRIPTION
As per DBD-Pg upstream commit[0], do not pass the return value of
substr() directly to pg_putline(). Instead, assign the output a
variable and pass that. Without this fix, the pending files list is
never properly initialized and indexing never takes place.

[0] https://github.com/bucardo/dbdpg/commit/0abc736a3369c05b26d3b04bcb3b0e91e04dc096